### PR TITLE
Make loquat name configurable

### DIFF
--- a/src/main/scala/ohnosequences/loquat/loquats.scala
+++ b/src/main/scala/ohnosequences/loquat/loquats.scala
@@ -58,7 +58,7 @@ case object LoquatOps extends LazyLogging {
     user: LoquatUser,
     managerUserScript: String
   ): Unit = {
-    logger.info(s"Deploying loquat: ${config.loquatName} v${config.loquatVersion}")
+    logger.info(s"Deploying loquat: v${config.loquatId}")
 
     if(user.validate.nonEmpty)
       logger.error("User validation failed. Fix it and try to deploy again.")
@@ -128,7 +128,7 @@ case object LoquatOps extends LazyLogging {
     aws: AWSClients,
     reason: AnyTerminationReason
   ): Unit = {
-    logger.info(s"undeploying loquat: ${config.loquatName} v${config.loquatVersion}")
+    logger.info(s"Undeploying loquat: ${config.loquatId}")
 
     val names = config.resourceNames
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.0-futures-SNAPSHOT"
+version in ThisBuild := "2.0.0-name-SNAPSHOT"


### PR DESCRIPTION
Now loquat id is derived from the artifact metadata, so if you have several loquats in the same artifact, they all have same names (which will lead to the problems with the autoscaling groups and other resources)