### PR TITLE
Simplify input data locations handling

### DIFF
--- a/src/main/scala/ohnosequences/loquat/dataProcessing.scala
+++ b/src/main/scala/ohnosequences/loquat/dataProcessing.scala
@@ -17,25 +17,24 @@ import better.files._
 
 trait AnyProcessingContext {
 
-  val  workingDir: File
+  val workingDir: File
+  val inputDir: File
 
   type DataSet <: AnyDataSet
-  val  dataSet: DataSet
 
   /* user can get the file corresponding to the given data key */
-  def file[K <: AnyData](key: K)(implicit
+  def inputFile[K <: AnyData](key: K)(implicit
     isIn: K isOneOf DataSet#Keys#Types#Hola
-  ): File = workingDir / "input" / key.label
+  ): File = inputDir / key.label
 
   /* or create a file instance in the orking directory */
   def /(name: String): File = workingDir / name
 }
 
-// TODO predicate on DV for all of them being files?
 case class ProcessingContext[
   D <: AnyDataSet
-](val dataSet: D,
-  val workingDir: File
+](val workingDir: File,
+  val inputDir: File
 ) extends AnyProcessingContext {
   type DataSet = D
 }
@@ -55,8 +54,8 @@ trait AnyDataProcessingBundle extends AnyBundle {
   def process(context: ProcessingContext[Input]): Instructions[OutputFiles]
 
 
-  final def runProcess(workingDir: File): Result[Map[String, File]] = {
-    process(ProcessingContext(input, workingDir))
+  final def runProcess(workingDir: File, inputDir: File): Result[Map[String, File]] = {
+    process(ProcessingContext[Input](workingDir, inputDir))
       .run(workingDir.toJava) match {
         case Failure(tr) => Failure(tr)
         case Success(tr, of) => Success(tr, toMap(of))

--- a/src/main/scala/ohnosequences/loquat/dataProcessing.scala
+++ b/src/main/scala/ohnosequences/loquat/dataProcessing.scala
@@ -26,7 +26,7 @@ trait AnyProcessingContext {
   /* user can get the file corresponding to the given data key */
   def file[K <: AnyData](key: K)(implicit
       lookup: AnyApp1At[
-        FindS[AnyDenotation.Of[K] { type Value = FileDataLocation }],
+        findS[AnyDenotation.Of[K] { type Value = FileDataLocation }],
         DataSetLocations[DataSet, FileDataLocation]
       ] { type Y = K := FileDataLocation }
     ): File = lookup(dataFiles).value.location

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -167,7 +167,7 @@ class DataProcessor(
       }
 
       logger.info("processing data in: " + workingDir.path)
-      val result = instructionsBundle.runProcess(workingDir)
+      val result = instructionsBundle.runProcess(workingDir, inputDir)
 
       val resultDescription = ProcessingResult(dataMapping.id, result.toString)
 

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -167,7 +167,7 @@ class DataProcessor(
       }
 
       logger.info("processing data in: " + workingDir.path)
-      val result = instructionsBundle.runProcess(workingDir, inputFilesMap)
+      val result = instructionsBundle.runProcess(workingDir)
 
       val resultDescription = ProcessingResult(dataMapping.id, result.toString)
 


### PR DESCRIPTION
_from the gitter chat_

Some ideas, which simplifies things in loquat a lot.

- no parsing of the input
- when creating a dataprocessing, you pass not just an input DataSet, but its denotation (record)
- in this denotation you say where you want to see the inpupt files (relatively to the working dir)
- no parsing is needed, only lookup of the locations by the data-key
- a worker has reference to the dataProcessing with this value, so when downloading objects, it just saves them in those paths (again, relatively to the working dir)


Advantages:
- you can tell where you want you inputs, intead of moving/copying files (as we are doing for cufflinks)
- working dir/sandbox is as before, so it doesn't influence the way things work
- no parsing input, no serializing output, simple and clean

Disadvantages:
- it may be a bit inconvenient to write this on one hand, but on the other, you can have a simple method, which constructs a denotation of the form reads1 := FileDataLocation("input" / reads1.label)
- things may collapse if you put two things at the same place, but on may happen now as well (and already happened once), if you have two datas with the same label

-------

An alternative solution would be just to put things in `cwd / "input" / data.label` (as it is now) and rely on this completely, i.e. without any parsing, having a "context" thing, with the simple method `file[D <: AnyData](d: D): File = workingDir / "input" / d.label`
