### PR TITLE
Input data as strings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,5 @@ buildInfoKeys    := Seq[BuildInfoKey](
 )
 
 //// Uncomment for testing: ////
-
-// // For including test code in the fat artifact:
-// unmanagedSourceDirectories in Compile += (scalaSource in Test).value
+// For including test code in the fat artifact:
+unmanagedSourceDirectories in Compile += (scalaSource in Test).value

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   // internal structure:
   "ohnosequences" %% "cosas"       % "0.8.0",
   "ohnosequences" %% "statika"     % "2.0.0-M5",
-  "ohnosequences" %% "datasets"    % "0.2.0",
+  "ohnosequences" %% "datasets"    % "0.3.0-SNAPSHOT",
   // amazon:
   "ohnosequences" %% "aws-scala-tools" % "0.16.0",
   // files:

--- a/src/main/scala/ohnosequences/loquat/dataMappings.scala
+++ b/src/main/scala/ohnosequences/loquat/dataMappings.scala
@@ -18,10 +18,10 @@ trait AnyDataMapping {
 
   /* These are records with references to the remote locations of
      where to get inputs and where to put outputs of the dataMapping */
-  type RemoteInput = DataSetLocations[DataProcessing#Input, S3DataLocation]
+  type RemoteInput = DataSetLocations[DataProcessing#Input, S3Resource]
   val  remoteInput: RemoteInput
 
-  type RemoteOutput = DataSetLocations[DataProcessing#Output, S3DataLocation]
+  type RemoteOutput = DataSetLocations[DataProcessing#Output, S3Resource]
   val  remoteOutput: RemoteOutput
 
 }
@@ -29,8 +29,8 @@ trait AnyDataMapping {
 case class DataMapping[
   DP <: AnyDataProcessingBundle
 ](val dataProcessing: DP)(
-  val remoteInput: DataSetLocations[DP#Input, S3DataLocation],
-  val remoteOutput: DataSetLocations[DP#Output, S3DataLocation]
+  val remoteInput: DataSetLocations[DP#Input, S3Resource],
+  val remoteOutput: DataSetLocations[DP#Output, S3Resource]
 ) extends AnyDataMapping {
 
   type DataProcessing = DP

--- a/src/main/scala/ohnosequences/loquat/dataMappings.scala
+++ b/src/main/scala/ohnosequences/loquat/dataMappings.scala
@@ -18,10 +18,10 @@ trait AnyDataMapping {
 
   /* These are records with references to the remote locations of
      where to get inputs and where to put outputs of the dataMapping */
-  type RemoteInput = DataSetLocations[DataProcessing#Input, S3Resource]
+  type RemoteInput = ResourcesSet[DataProcessing#Input, AnyRemoteResource]
   val  remoteInput: RemoteInput
 
-  type RemoteOutput = DataSetLocations[DataProcessing#Output, S3Resource]
+  type RemoteOutput = ResourcesSet[DataProcessing#Output, S3Resource]
   val  remoteOutput: RemoteOutput
 
 }
@@ -29,8 +29,8 @@ trait AnyDataMapping {
 case class DataMapping[
   DP <: AnyDataProcessingBundle
 ](val dataProcessing: DP)(
-  val remoteInput: DataSetLocations[DP#Input, S3Resource],
-  val remoteOutput: DataSetLocations[DP#Output, S3Resource]
+  val remoteInput: ResourcesSet[DP#Input, AnyRemoteResource],
+  val remoteOutput: ResourcesSet[DP#Output, S3Resource]
 ) extends AnyDataMapping {
 
   type DataProcessing = DP
@@ -40,9 +40,8 @@ case class DataMapping[
 case class ProcessingResult(id: String, message: String)
 
 /* This is easy to parse/serialize, but it's only for internal use. */
-private[loquat]
-case class SimpleDataMapping(
+private[loquat] case class SimpleDataMapping(
   val id: String,
-  val inputs: Map[String, AnyS3Address],
-  val outputs: Map[String, AnyS3Address]
+  val inputs: Map[String, AnyRemoteResource],
+  val outputs: Map[String, S3Resource]
 )

--- a/src/main/scala/ohnosequences/loquat/dataProcessing.scala
+++ b/src/main/scala/ohnosequences/loquat/dataProcessing.scala
@@ -43,7 +43,7 @@ trait AnyDataProcessingBundle extends AnyBundle {
   type Output <: AnyDataSet
   val  output: Output
 
-  type OutputFiles = DataSetLocations[Output, FileDataLocation]
+  type OutputFiles = DataSetLocations[Output, FileResource]
 
   // this is where you define what to do
   def process(context: ProcessingContext[Input]): AnyInstructions { type Out <: OutputFiles }

--- a/src/main/scala/ohnosequences/loquat/dataProcessing.scala
+++ b/src/main/scala/ohnosequences/loquat/dataProcessing.scala
@@ -43,7 +43,7 @@ trait AnyDataProcessingBundle extends AnyBundle {
   type Output <: AnyDataSet
   val  output: Output
 
-  type OutputFiles = DataSetLocations[Output, FileResource]
+  type OutputFiles = ResourcesSet[Output, FileResource]
 
   // this is where you define what to do
   def process(context: ProcessingContext[Input]): AnyInstructions { type Out <: OutputFiles }
@@ -53,7 +53,9 @@ trait AnyDataProcessingBundle extends AnyBundle {
     process(ProcessingContext[Input](workingDir, inputDir))
       .run(workingDir.toJava) match {
         case Failure(tr) => Failure(tr)
-        case Success(tr, of) => Success(tr, toMap(of))
+        case Success(tr, of) => Success(tr, 
+          toMap(of).map { case (k, v) => (k, v.resource) }
+        )
       }
   }
 

--- a/src/main/scala/ohnosequences/loquat/utils.scala
+++ b/src/main/scala/ohnosequences/loquat/utils.scala
@@ -22,11 +22,11 @@ case object utils {
   import java.util.concurrent._
 
 
-  type DataSetLocations[D <: AnyDataSet, L <: AnyDataLocation] =
+  type DataSetLocations[D <: AnyDataSet, L <: AnyDataResource] =
     D#Raw with AnyKList { type Bound = AnyDenotation { type Value = L } }
 
-  def toMap[V <: AnyDataLocation](l: AnyKList.Of[AnyDenotation { type Value <: V }]): Map[String, V#Location] =
-    l.asList.map{ d => (d.tpe.label, d.value.location) }.toMap
+  def toMap[V <: AnyDataResource](l: AnyKList.Of[AnyDenotation { type Value <: V }]): Map[String, V#Resource] =
+    l.asList.map{ d => (d.tpe.label, d.value.resource) }.toMap
 
 
   trait AnyStep extends LazyLogging

--- a/src/main/scala/ohnosequences/loquat/utils.scala
+++ b/src/main/scala/ohnosequences/loquat/utils.scala
@@ -22,11 +22,11 @@ case object utils {
   import java.util.concurrent._
 
 
-  type DataSetLocations[D <: AnyDataSet, L <: AnyDataResource] =
+  type ResourcesSet[D <: AnyDataSet, L <: AnyDataResource] =
     D#Raw with AnyKList { type Bound = AnyDenotation { type Value = L } }
 
-  def toMap[V <: AnyDataResource](l: AnyKList.Of[AnyDenotation { type Value <: V }]): Map[String, V#Resource] =
-    l.asList.map{ d => (d.tpe.label, d.value.resource) }.toMap
+  def toMap[V <: AnyDataResource](l: AnyKList.Of[AnyDenotation { type Value <: V }]): Map[String, V] =
+    l.asList.map{ d => (d.tpe.label, d.value) }.toMap
 
 
   trait AnyStep extends LazyLogging

--- a/src/main/scala/ohnosequences/loquat/utils.scala
+++ b/src/main/scala/ohnosequences/loquat/utils.scala
@@ -22,8 +22,9 @@ case object utils {
   import java.util.concurrent._
 
 
-  type ResourcesSet[D <: AnyDataSet, L <: AnyDataResource] =
-    D#Raw with AnyKList { type Bound = AnyDenotation { type Value = L } }
+  type ResourcesSet[D <: AnyDataSet, R <: AnyDataResource] =
+    D#Raw with AnyKList.withBound[AnyDenotation { type Value <: R }]
+    // { type Bound = AnyDenotation { type Value = R } }
 
   def toMap[V <: AnyDataResource](l: AnyKList.Of[AnyDenotation { type Value <: V }]): Map[String, V] =
     l.asList.map{ d => (d.tpe.label, d.value) }.toMap

--- a/src/test/scala/ohnosequences/loquat/test/config.scala
+++ b/src/test/scala/ohnosequences/loquat/test/config.scala
@@ -2,7 +2,7 @@ package ohnosequences.loquat.test
 
 import ohnosequences.loquat._
 import ohnosequences.awstools._, regions.Region._, ec2._, InstanceType._, autoscaling._
-import ohnosequences.statika._, bundles._, aws._
+import ohnosequences.statika._, aws._
 
 case object config {
 

--- a/src/test/scala/ohnosequences/loquat/test/data.scala
+++ b/src/test/scala/ohnosequences/loquat/test/data.scala
@@ -1,14 +1,16 @@
 package ohnosequences.loquat.test
 
-import ohnosequences.datasets._, fileType._
+import ohnosequences.datasets._
 import ohnosequences.cosas._, klists._, types._, records._
 
 case object data {
 
   // inputs:
-  case object matrix extends FileData("matrix")(txt)
+  case object prefix extends Data("prefix")
+  case object text extends Data("text")
+  case object matrix extends FileData("matrix")("txt")
 
   // outputs:
-  case object transposed extends FileData("transposed")(txt)
+  case object transposed extends FileData("transposed")("txt")
 
 }

--- a/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
@@ -1,7 +1,7 @@
 package ohnosequences.loquat.test
 
 import ohnosequences.awstools.s3._
-import ohnosequences.datasets._, S3DataLocation._
+import ohnosequences.datasets._, S3Resource._
 import ohnosequences.cosas._, klists._, types._
 import ohnosequences.loquat._, test.data._, test.dataProcessing._
 
@@ -13,10 +13,10 @@ case object dataMappings {
   val dataMapping = DataMapping(processingBundle)(
     remoteInput =
       matrix.inS3(input / matrix.label) ::
-      *[AnyDenotation { type Value = S3DataLocation }],
+      *[AnyDenotation { type Value = S3Resource }],
     remoteOutput =
       transposed.inS3(output / transposed.label) ::
-      *[AnyDenotation { type Value = S3DataLocation }]
+      *[AnyDenotation { type Value = S3Resource }]
   )
 
 }

--- a/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
@@ -12,11 +12,17 @@ case object dataMappings {
 
   val dataMapping = DataMapping(processingBundle)(
     remoteInput =
-      matrix.inS3(input / matrix.label) ::
-      *[AnyDenotation { type Value = S3Resource }],
+      prefix("viva-loquat") ::
+      text("""bluh-blah!!!
+      |foo bar
+      |qux?
+      |¡buh™!
+      |""".stripMargin) ::
+      matrix(input / matrix.label) ::
+      *[AnyDenotation { type Value <: AnyRemoteResource }],
     remoteOutput =
-      transposed.inS3(output / transposed.label) ::
-      *[AnyDenotation { type Value = S3Resource }]
+      transposed(output / transposed.label) ::
+      *[AnyDenotation { type Value <: S3Resource }]
   )
 
 }

--- a/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
@@ -3,7 +3,7 @@ package ohnosequences.loquat.test
 import ohnosequences.datasets._
 import ohnosequences.loquat._, test.data._
 import ohnosequences.statika.instructions._
-import ohnosequences.datasets._, FileDataLocation._
+import ohnosequences.datasets._, FileResource._
 import ohnosequences.cosas._, klists._, types._, records._
 import better.files._
 
@@ -30,7 +30,7 @@ case object dataProcessing {
       } -&-
       success("transposed",
         transposed.inFile(outFile) ::
-        *[AnyDenotation { type Value = FileDataLocation }]
+        *[AnyDenotation { type Value = FileResource }]
       )
     }
   }

--- a/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
@@ -2,14 +2,14 @@ package ohnosequences.loquat.test
 
 import ohnosequences.datasets._
 import ohnosequences.loquat._, test.data._
-import ohnosequences.statika.instructions._
+import ohnosequences.statika._
 import ohnosequences.datasets._, FileResource._
 import ohnosequences.cosas._, klists._, types._, records._
 import better.files._
 
 case object dataProcessing {
 
-  case object inputData extends DataSet(matrix :×: |[AnyData])
+  case object inputData extends DataSet(prefix :×: text :×: matrix :×: |[AnyData])
   case object outputData extends DataSet(transposed :×: |[AnyData])
 
   case object processingBundle extends DataProcessingBundle()(
@@ -21,16 +21,20 @@ case object dataProcessing {
 
     def process(context: ProcessingContext[Input]): AnyInstructions { type Out <: OutputFiles } = {
 
-      val outFile: File = context / "transposed.txt"
+      val txt: String = context.inputFile(text).contentAsString
+      val prfx: String = context.inputFile(prefix).contentAsString
+
+      val outFile: File = context / s"${prfx}.transposed.txt"
 
       LazyTry {
         val matrixRows = context.inputFile(matrix).lines
         val trans = matrixRows.map{ _.reverse }.toList.reverse
         outFile.createIfNotExists().overwrite(trans.mkString("\n"))
+        outFile.append(txt)
       } -&-
       success("transposed",
-        transposed.inFile(outFile) ::
-        *[AnyDenotation { type Value = FileResource }]
+        transposed(outFile) ::
+        *[AnyDenotation { type Value <: FileResource }]
       )
     }
   }

--- a/src/test/scala/ohnosequences/loquat/test/md5.scala
+++ b/src/test/scala/ohnosequences/loquat/test/md5.scala
@@ -2,7 +2,7 @@
 //
 // import ohnosequences.loquat._, test.data._
 // import ohnosequences.statika.instructions._
-// import ohnosequences.datasets._, FileDataLocation._
+// import ohnosequences.datasets._, FileResource._
 // import ohnosequences.cosas._, klists._, types._, records._
 // import better.files._
 //


### PR DESCRIPTION
Same thing which motivated the _nisperito_ fork:

- being able to pass input data as strings
- send them directly in the SQS messages
- when getting the message distinguish between files to get from S3 and strings
- pass it to the `dataProcessing`

This requires changes in the datasets lib, to distringuish between `FileData` and ...`StringData`.
