### PR TITLE
Input folders are handled wrong by the processing context

### DIFF
--- a/src/main/scala/ohnosequences/loquat/dataProcessing.scala
+++ b/src/main/scala/ohnosequences/loquat/dataProcessing.scala
@@ -16,14 +16,14 @@ import better.files._
 trait AnyProcessingContext {
 
   val workingDir: File
-  val inputDir: File
+  val inputFiles: Map[String, File]
 
   type DataSet <: AnyDataSet
 
   /* user can get the file corresponding to the given data key */
   def inputFile[K <: AnyData](key: K)(implicit
     isIn: K isOneOf DataSet#Keys#Types#AllTypes
-  ): File = inputDir / key.label
+  ): File = inputFiles(key.label)
 
   /* or create a file instance in the orking directory */
   def /(name: String): File = workingDir / name
@@ -31,7 +31,7 @@ trait AnyProcessingContext {
 
 case class ProcessingContext[D <: AnyDataSet](
   val workingDir: File,
-  val inputDir: File
+  val inputFiles: Map[String, File]
 ) extends AnyProcessingContext { type DataSet = D }
 
 
@@ -49,8 +49,8 @@ trait AnyDataProcessingBundle extends AnyBundle {
   def process(context: ProcessingContext[Input]): AnyInstructions { type Out <: OutputFiles }
 
 
-  final def runProcess(workingDir: File, inputDir: File): Result[Map[String, File]] = {
-    process(ProcessingContext[Input](workingDir, inputDir))
+  final def runProcess(workingDir: File, inputFiles: Map[String, File]): Result[Map[String, File]] = {
+    process(ProcessingContext[Input](workingDir, inputFiles))
       .run(workingDir.toJava) match {
         case Failure(tr) => Failure(tr)
         case Success(tr, of) => Success(tr,

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -160,7 +160,7 @@ class DataProcessor(
       val transferManager = new TransferManager(aws.s3.s3)
 
       logger.info("Preparing dataMapping input")
-      val inputFilesMap: Map[String, File] = dataMapping.inputs.map { case (name, resource) =>
+      val inputFiles: Map[String, File] = dataMapping.inputs.map { case (name, resource) =>
 
         logger.debug(s"Trying to create input object: [${name}] from [${resource}]")
 
@@ -179,7 +179,7 @@ class DataProcessor(
       }
 
       logger.info("Processing data in: " + workingDir.path)
-      val result = instructionsBundle.runProcess(workingDir, inputDir)
+      val result = instructionsBundle.runProcess(workingDir, inputFiles)
 
       val resultDescription = ProcessingResult(dataMapping.id, result.toString)
 


### PR DESCRIPTION
If you are downloading an input `S3folder(bucket, key)` to a `destination: File`, the the result (the content of that S3 folder will be in `destination / key`.

But if you then refer to this input as `context.inputFile(dataKey)`, you will get `context / "input" / dataKey.label` which is likely just the `destination` (without that appended path suffix).