### PR TITLE
SQS polling gets stuck

### DIFF
--- a/src/main/scala/ohnosequences/loquat/terminator.scala
+++ b/src/main/scala/ohnosequences/loquat/terminator.scala
@@ -8,12 +8,9 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 
-import ohnosequences.awstools.s3._
 import ohnosequences.awstools.sqs
 
 import com.amazonaws.{ services => amzn }
-
-import java.util.concurrent._
 
 import scala.collection.JavaConversions._
 import scala.util.Try
@@ -38,8 +35,8 @@ case class TerminationDaemonBundle(
 
   def instructions: AnyInstructions = LazyTry[Unit] {
     scheduler.repeat(
-      after = 3.minutes,
-      every = 30.seconds //3.minutes
+      after = 1.minute,
+      every = 1.minute
     )(checkConditions)
   } -&- say("Termination daemon started")
 
@@ -50,17 +47,32 @@ case class TerminationDaemonBundle(
     aws.sqs.getQueueByName(config.resourceNames.outputQueue) match {
       case None => logger.error(s"Couldn't access output queue: ${config.resourceNames.outputQueue}")
       case Some(outputQueue) =>
-        receiveProcessingResults(outputQueue).foreach { result =>
-          successResults.put(result.id, result.message)
+        receiveProcessingResults(outputQueue) match {
+          case scala.util.Failure(t) => {
+            logger.error(s"Couldn't poll the queue: ${config.resourceNames.outputQueue}\n${t.getMessage()}")
+          }
+          case scala.util.Success(polledMessages) => {
+            polledMessages.foreach { result =>
+              successResults.put(result.id, result.message)
+            }
+          }
         }
     }
     logger.debug(s"Success results: ${successResults.size}")
 
+    // logger.debug(s"Failure results: ${failedResults.size} (before polling)")
     aws.sqs.getQueueByName(config.resourceNames.errorQueue) match {
       case None => logger.error(s"Couldn't access error queue: ${config.resourceNames.errorQueue}")
       case Some(errorQueue) =>
-        receiveProcessingResults(errorQueue).foreach { result =>
-          failedResults.put(result.id, result.message)
+        receiveProcessingResults(errorQueue) match {
+          case scala.util.Failure(t) => {
+            logger.error(s"Couldn't poll the queue: ${config.resourceNames.errorQueue}\n${t.getMessage()}")
+          }
+          case scala.util.Success(polledMessages) => {
+            polledMessages.foreach { result =>
+              failedResults.put(result.id, result.message)
+            }
+          }
         }
     }
     logger.debug(s"Failure results: ${failedResults.size}")
@@ -96,7 +108,7 @@ case class TerminationDaemonBundle(
     reason.foreach{ LoquatOps.undeploy(config, aws, _) }
   }
 
-  def receiveProcessingResults(queue: sqs.Queue): List[ProcessingResult] = {
+  def receiveProcessingResults(queue: sqs.Queue): Try[List[ProcessingResult]] = {
 
     /* Note that this request does so called short-polling, see the [Amazon documentation](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/model/ReceiveMessageRequest.html).
        Long polling doesn't work here, because it returns too many responses with the same messages (so it's not clear when you can stop polling).
@@ -115,24 +127,45 @@ case class TerminationDaemonBundle(
     */
     def pollQueue: List[String] = {
 
+      // val timeout: Deadline = 20.seconds.fromNow
+      // val timeout: FiniteDuration = 30.seconds
+      // logger.debug(s">>> Started polling")
+      // val startTime: FiniteDuration = System.currentTimeMillis.millis
+      // def timeSpent: FiniteDuration = System.currentTimeMillis.millis - startTime
+
       @scala.annotation.tailrec
         def pollQueue_rec(
           acc: scala.collection.mutable.ListBuffer[String],
           tries: Int
         ): List[String] = {
+          Thread.sleep(300)
           val response = getMessageBodies()
 
+          // logger.debug(s"Polling took ${timeSpent.toSeconds} seconds")
+          // if (timeout.isOverdue()) {
+          // if (timeSpent > timeout) {
+          //   // logger.debug(s"Polling took more than ${timeout.toSeconds} seconds. Stopping!")
+          //   acc.toList
+          // } else {
           if (response.isEmpty) {
-            if (tries > 5) acc.toList
-            else pollQueue_rec(acc ++= response, tries + 1)
+            if (tries > 5) {
+              acc.toList
+            } else {
+              pollQueue_rec(acc ++= response, tries + 1)
+            }
+          } else {
+            pollQueue_rec(acc ++= response, 0)
           }
-          else pollQueue_rec(acc ++= response, 0)
         }
 
-      pollQueue_rec(scala.collection.mutable.ListBuffer(), 0)
+      val result = pollQueue_rec(scala.collection.mutable.ListBuffer(), 0)
+      // logger.debug(s"<<< Finished polling. got [$result.length] messages")
+      result
     }
 
-    pollQueue.map { upickle.default.read[ProcessingResult](_) }
+    Try {
+      pollQueue.map { upickle.default.read[ProcessingResult](_) }
+    }
 
   }
 

--- a/src/test/scala/ohnosequences/loquat/test/config.scala
+++ b/src/test/scala/ohnosequences/loquat/test/config.scala
@@ -28,17 +28,17 @@ case object config {
     val workersConfig = WorkersConfig(
       instanceSpecs = InstanceSpecs(defaultAMI, m3.medium),
       purchaseModel = Spot(maxPrice = Some(0.1)),
-      groupSize = AutoScalingGroupSize(0, 1, 1)
+      groupSize = AutoScalingGroupSize(0, 10, 20)
     )
 
     val terminationConfig = TerminationConfig(
       terminateAfterInitialDataMappings = true
     )
 
-    val N = 10
+    val N = 5000
     val dataMappings: List[AnyDataMapping] = (1 to N).toList.map{ _ => test.dataMappings.dataMapping }
 
-    val checkInputObjects = true
+    val checkInputObjects = false
   }
 
   case object testLoquat extends Loquat(testConfig, test.dataProcessing.processingBundle)


### PR DESCRIPTION
I guess, if there are too few messages, it will never get "an empty response 5+ times in a row". So a timeout condition should be added to the polling loop.