### PR TITLE
Make outputs uploading log less noisy

### DIFF
--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -162,7 +162,7 @@ class DataProcessor(
       logger.info("Preparing dataMapping input")
       val inputFiles: Map[String, File] = dataMapping.inputs.map { case (name, resource) =>
 
-        logger.debug(s"Trying to create input object: [${name}] from [${resource}]")
+        logger.debug(s"Trying to create input object [${name}]")
 
         resource match {
           case MessageResource(msg) => {
@@ -199,7 +199,7 @@ class DataProcessor(
           if (outputMap.keys.forall(_.exists)) {
 
             val uploadTries = outputMap map { case (file, s3Address) =>
-              logger.info(s"Publishing output object: ${file} -> ${s3Address}")
+              logger.info(s"Publishing output object: [${file.name}]")
               transferManager.upload(
                 file,
                 s3Address,


### PR DESCRIPTION
```
01:39:10.726 [ForkJoinPool-1-worker-5] INFO  ohnosequences.loquat.DataProcessor - Publishing output object: file:///tmp/3603288524127833315.counts.index -> s3://era7p/dimt1/data/out/counts/ERR030872/34_mer.counts
Uploading object
from: /tmp/3603288524127833315.counts.index
to: s3://era7p/dimt1/data/out/counts/ERR030872/34_mer.counts
```

DRY