### PR TITLE
Check that datamappings have all data keys defined

### DIFF
--- a/src/main/scala/ohnosequences/loquat/dataMappings.scala
+++ b/src/main/scala/ohnosequences/loquat/dataMappings.scala
@@ -16,18 +16,26 @@ trait AnyDataMapping {
   // This label is just to distinguish data mappings, it is not an ID
   val label: String
 
+  type DataProcessing <: AnyDataProcessingBundle
+  val  dataProcessing: DataProcessing
+
+
   type RemoteInput = Map[AnyData, AnyRemoteResource]
   val  remoteInput: RemoteInput
 
   type RemoteOutput = Map[AnyData, S3Resource]
   val  remoteOutput: RemoteOutput
-
 }
 
-case class DataMapping(val label: String)(
-  val remoteInput:  Map[AnyData, AnyRemoteResource],
+case class DataMapping[DP <: AnyDataProcessingBundle](
+  val label: String,
+  val dataProcessing: DP
+)(val remoteInput:  Map[AnyData, AnyRemoteResource],
   val remoteOutput: Map[AnyData, S3Resource]
-) extends AnyDataMapping
+) extends AnyDataMapping {
+
+  type DataProcessing = DP
+}
 
 
 case class ProcessingResult(id: String, message: String)

--- a/src/main/scala/ohnosequences/loquat/dataMappings.scala
+++ b/src/main/scala/ohnosequences/loquat/dataMappings.scala
@@ -11,7 +11,7 @@ import better.files._
 import upickle.Js
 
 
-trait AnyDataMapping {
+trait AnyDataMapping { dataMapping =>
 
   // This label is just to distinguish data mappings, it is not an ID
   val label: String
@@ -25,6 +25,38 @@ trait AnyDataMapping {
 
   type RemoteOutput = Map[AnyData, S3Resource]
   val  remoteOutput: RemoteOutput
+
+  def checkDataKeys: Seq[String] = {
+
+    def keyLabels(rec: AnyRecordType): Set[String] =
+      rec.keys.types.asList.toSet.map { tpe: AnyType => tpe.label }
+
+    val mapInputKeys = remoteInput.keySet.map{ _.label }
+    val dataInputKeys = keyLabels(dataProcessing.input)
+
+    val missingInputKeys: Set[String] = dataInputKeys diff mapInputKeys
+    val extraInputKeys:   Set[String] = mapInputKeys diff dataInputKeys
+
+
+    val mapOutputKeys = remoteOutput.keySet.map{ _.label }
+    val dataOutputKeys = keyLabels(dataProcessing.output)
+
+    val missingOutputKeys: Set[String] = dataOutputKeys diff mapOutputKeys
+    val extraOutputKeys:   Set[String] = mapOutputKeys diff dataOutputKeys
+
+    missingInputKeys.toSeq.map { key =>
+      s"The [${key}] input key is missing in the remoteInput of [${dataMapping.label}]"
+    } ++
+    extraInputKeys.toSeq.map { key =>
+      s"The [${key}] key doesn't exist in the [${dataMapping.label}] input dataset"
+    } ++
+    missingOutputKeys.toSeq.map { key =>
+      s"The [${key}] output key is missing in the remoteOutput of [${dataMapping.label}]"
+    } ++
+    extraOutputKeys.toSeq.map { key =>
+      s"The [${key}] key doesn't exist in the [${dataMapping.label}] output dataset"
+    }
+  }
 }
 
 case class DataMapping[DP <: AnyDataProcessingBundle](

--- a/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
@@ -10,7 +10,7 @@ case object dataMappings {
   val input = S3Folder("loquat.testing", "input")
   val output = S3Folder("loquat.testing", "output")
 
-  val dataMapping = DataMapping("foo")(
+  val dataMapping = DataMapping("foo", processingBundle)(
     remoteInput = Map(
       prefix -> MessageResource("viva-loquat"),
       text -> MessageResource("""bluh-blah!!!


### PR DESCRIPTION
Followup for #45.

A runtime config check that just goes through each `Input`/`Output` dataset (`.asList.map{ _.label }`) and checks that corresponding datamappings `remoteInputs.keys`/`remoteOutputs.keys` are the same (up to reordering)