### PR TITLE
Too many open files

### DIFF
--- a/src/main/scala/ohnosequences/loquat/configs/loquat.scala
+++ b/src/main/scala/ohnosequences/loquat/configs/loquat.scala
@@ -53,8 +53,6 @@ abstract class AnyLoquatConfig extends AnyConfig {
   lazy val amiEnv: AnyLinuxAMIEnvironment = amznAMIEnv(ami)
   lazy val region: Region = ami.region
 
-  final val workingDir: File = file"/media/ephemeral0/applicator/loquat"
-
   lazy final val fatArtifactS3Object: S3Object = {
     val s3url = """s3://(.+)/(.+)""".r
     metadata.artifactUrl match {

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -62,6 +62,8 @@ class DataProcessor(
   val instructionsBundle: AnyDataProcessingBundle
 ) extends LazyLogging {
 
+  final val workingDir: File = file"/media/ephemeral0/applicator/loquat"
+
   lazy val aws = instanceAWSClients(config)
 
   // FIXME: don't use Option.get
@@ -239,7 +241,6 @@ class DataProcessor(
 
     logger.info("DataProcessor started at " + instance.map(_.getInstanceId))
 
-    val workingDir = config.workingDir
 
     logger.info("Creating working directory: " + workingDir.path)
     workingDir.createDirectories()

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -232,6 +232,8 @@ class DataProcessor(
     } catch {
       case t: Throwable => {
         logger.error("Fatal failure during dataMapping processing", t)
+        errorQueue.sendMessage(upickle.default.write(t.getMessage))
+        terminateWorker
         Failure(Seq(t.getMessage))
       }
     }

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -234,8 +234,6 @@ class DataProcessor(
 
     logger.info("DataProcessor started at " + instance.map(_.getInstanceId))
 
-    val transferManager = new TransferManager(aws.s3.s3)
-
     val workingDir = config.workingDir
 
     logger.info("Creating working directory: " + workingDir.path)
@@ -243,6 +241,8 @@ class DataProcessor(
 
     while(!stopped) {
       try {
+        val transferManager = new TransferManager(aws.s3.s3)
+
         val message = waitForDataMapping(inputQueue)
 
         // instance.foreach(_.createTag(StatusTag.processing))
@@ -269,6 +269,7 @@ class DataProcessor(
           inputQueue.deleteMessage(message)
         }
 
+        transferManager.shutdownNow(false)
       } catch {
         case e: Throwable => {
           logger.error(s"This instance will terminated due to a fatal error: ${e.getMessage}")
@@ -277,8 +278,6 @@ class DataProcessor(
         }
       }
     }
-
-    transferManager.shutdownNow()
   }
 
 }

--- a/src/test/scala/ohnosequences/loquat/test/config.scala
+++ b/src/test/scala/ohnosequences/loquat/test/config.scala
@@ -28,14 +28,14 @@ case object config {
     val workersConfig = WorkersConfig(
       instanceSpecs = InstanceSpecs(defaultAMI, m3.medium),
       purchaseModel = Spot(maxPrice = Some(0.1)),
-      groupSize = AutoScalingGroupSize(0, 10, 20)
+      groupSize = AutoScalingGroupSize(0, 1, 20)
     )
 
     val terminationConfig = TerminationConfig(
       terminateAfterInitialDataMappings = true
     )
 
-    val N = 5000
+    val N = 10000
     val dataMappings: List[AnyDataMapping] = (1 to N).toList.map{ _ => test.dataMappings.dataMapping }
 
     val checkInputObjects = false

--- a/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
@@ -12,16 +12,16 @@ case object dataMappings {
 
   val dataMapping = DataMapping("foo", processingBundle)(
     remoteInput = Map(
-      // prefix -> MessageResource("viva-loquat"),
-      // text -> MessageResource("""bluh-blah!!!
-      // |foo bar
-      // |qux?
-      // |¡buh™!
-      // |""".stripMargin),
-      // matrix -> S3Resource(input / matrix.label)
+      prefix -> MessageResource("viva-loquat"),
+      text -> MessageResource("""bluh-blah!!!
+      |foo bar
+      |qux?
+      |¡buh™!
+      |""".stripMargin),
+      matrix -> S3Resource(input / matrix.label)
     ),
     remoteOutput = Map(
-      // transposed -> S3Resource(output / transposed.label)
+      transposed -> S3Resource(output / transposed.label)
     )
   )
 

--- a/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataMappings.scala
@@ -12,16 +12,16 @@ case object dataMappings {
 
   val dataMapping = DataMapping("foo", processingBundle)(
     remoteInput = Map(
-      prefix -> MessageResource("viva-loquat"),
-      text -> MessageResource("""bluh-blah!!!
-      |foo bar
-      |qux?
-      |¡buh™!
-      |""".stripMargin),
-      matrix -> S3Resource(input / matrix.label)
+      // prefix -> MessageResource("viva-loquat"),
+      // text -> MessageResource("""bluh-blah!!!
+      // |foo bar
+      // |qux?
+      // |¡buh™!
+      // |""".stripMargin),
+      // matrix -> S3Resource(input / matrix.label)
     ),
     remoteOutput = Map(
-      transposed -> S3Resource(output / transposed.label)
+      // transposed -> S3Resource(output / transposed.label)
     )
   )
 

--- a/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
@@ -9,8 +9,8 @@ import better.files._
 
 case object dataProcessing {
 
-  case object inputData extends DataSet(prefix :×: text :×: matrix :×: |[AnyData])
-  case object outputData extends DataSet(transposed :×: |[AnyData])
+  case object inputData extends DataSet(|[AnyData])
+  case object outputData extends DataSet(|[AnyData])
 
   case object processingBundle extends DataProcessingBundle()(
     inputData,
@@ -21,19 +21,19 @@ case object dataProcessing {
 
     def process(context: ProcessingContext[Input]): AnyInstructions { type Out <: OutputFiles } = {
 
-      val txt: String = context.inputFile(text).contentAsString
-      val prfx: String = context.inputFile(prefix).contentAsString
+      // val txt: String = context.inputFile(text).contentAsString
+      // val prfx: String = context.inputFile(prefix).contentAsString
 
-      val outFile: File = context / s"${prfx}.transposed.txt"
+      // val outFile: File = (context / s"${prfx}.transposed.txt").createIfNotExists()
 
-      LazyTry {
-        val matrixRows = context.inputFile(matrix).lines
-        val trans = matrixRows.map{ _.reverse }.toList.reverse
-        outFile.createIfNotExists().overwrite(trans.mkString("\n"))
-        outFile.append(txt)
-      } -&-
+      // LazyTry {
+      //   val matrixRows = context.inputFile(matrix).lines
+      //   val trans = matrixRows.map{ _.reverse }.toList.reverse
+      //   outFile.createIfNotExists().overwrite(trans.mkString("\n"))
+      //   outFile.append(txt)
+      // } -&-
       success("transposed",
-        transposed(outFile) ::
+        // transposed(outFile) ::
         *[AnyDenotation { type Value <: FileResource }]
       )
     }

--- a/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
@@ -9,8 +9,8 @@ import better.files._
 
 case object dataProcessing {
 
-  case object inputData extends DataSet(|[AnyData])
-  case object outputData extends DataSet(|[AnyData])
+  case object inputData extends DataSet(prefix :×: text :×: matrix :×: |[AnyData])
+  case object outputData extends DataSet(transposed :×: |[AnyData])
 
   case object processingBundle extends DataProcessingBundle()(
     inputData,
@@ -21,19 +21,19 @@ case object dataProcessing {
 
     def process(context: ProcessingContext[Input]): AnyInstructions { type Out <: OutputFiles } = {
 
-      // val txt: String = context.inputFile(text).contentAsString
-      // val prfx: String = context.inputFile(prefix).contentAsString
+      val txt: String = context.inputFile(text).contentAsString
+      val prfx: String = context.inputFile(prefix).contentAsString
 
-      // val outFile: File = (context / s"${prfx}.transposed.txt").createIfNotExists()
+      val outFile: File = (context / s"${prfx}.transposed.txt").createIfNotExists()
 
-      // LazyTry {
-      //   val matrixRows = context.inputFile(matrix).lines
-      //   val trans = matrixRows.map{ _.reverse }.toList.reverse
-      //   outFile.createIfNotExists().overwrite(trans.mkString("\n"))
-      //   outFile.append(txt)
-      // } -&-
+      LazyTry {
+        val matrixRows = context.inputFile(matrix).lines
+        val trans = matrixRows.map{ _.reverse }.toList.reverse
+        outFile.createIfNotExists().overwrite(trans.mkString("\n"))
+        outFile.append(txt)
+      } -&-
       success("transposed",
-        // transposed(outFile) ::
+        transposed(outFile) ::
         *[AnyDenotation { type Value <: FileResource }]
       )
     }


### PR DESCRIPTION
When a worker processes too many tasks, it exceeds the limit of open files, because it deletes working directory for every task, but it stays in somewhere as an open descriptor or whatever. See https://github.com/ohnosequences/mg7/pull/26 for details.