### PR TITLE
Still make skipping empty results optional

### DIFF
--- a/src/main/scala/ohnosequences/loquat/configs/loquat.scala
+++ b/src/main/scala/ohnosequences/loquat/configs/loquat.scala
@@ -42,7 +42,10 @@ abstract class AnyLoquatConfig extends AnyConfig {
   val dataMappings: List[AnyDataMapping]
 
   /* This setting switches the check of existence of the input S3 objects */
-  val checkInputObjects: Boolean
+  val checkInputObjects: Boolean = true
+
+  /* This setting determines whether empty output files will be uploaded or not */
+  val skipEmptyResults: Boolean = true
 
 
 

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -192,7 +192,7 @@ class DataProcessor(
           if (outputMap.keys.forall(_.exists)) {
 
             val uploadTries = outputMap flatMap { case (file, s3Address) =>
-              if (file.isEmpty) {
+              if (config.skipEmptyResults && file.isEmpty) {
                 logger.info(s"Output file [${file.name}] is empty. Skipping it.")
                 None
               } else {

--- a/src/test/scala/ohnosequences/loquat/test/config.scala
+++ b/src/test/scala/ohnosequences/loquat/test/config.scala
@@ -38,7 +38,7 @@ case object config {
     val N = 10000
     val dataMappings: List[AnyDataMapping] = (1 to N).toList.map{ _ => test.dataMappings.dataMapping }
 
-    val checkInputObjects = false
+    override val checkInputObjects = false
   }
 
   case object testLoquat extends Loquat(testConfig, test.dataProcessing.processingBundle)


### PR DESCRIPTION
#59 follow up. 
In some cases the subsequent loquat relies on existence of fixed output files from the previous one. Whether they are empty or not, they have to be present, otherwise the pipeline is broken. In the end an empty result is also a result. 
So I'm adding a configuration option to turn off #59 when needed.