### PR TITLE
Move data-mappings list out from the config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-Nice.scalaProject
-
 name         := "loquat"
 description  := "🍋"
 organization := "ohnosequences"
@@ -32,19 +30,11 @@ dependencyOverrides ++= Set(
 // FIXME: warts should be turn on back after the code clean up
 wartremoverErrors in (Compile, compile) := Seq()
 
-fatArtifactSettings
 
-enablePlugins(BuildInfoPlugin)
-buildInfoPackage := "generated.metadata"
-buildInfoObject  := name.value.split("""\W""").map(_.capitalize).mkString
-buildInfoOptions := Seq(BuildInfoOption.Traits("ohnosequences.statika.AnyArtifactMetadata"))
-buildInfoKeys    := Seq[BuildInfoKey](
-  organization,
-  version,
-  "artifact" -> name.value.toLowerCase,
-  "artifactUrl" -> fatArtifactUrl.value
-)
+generateStatikaMetadataIn(Test)
 
-// //// Uncomment for testing: ////
-// // For including test code in the fat artifact:
-// unmanagedSourceDirectories in Compile += (scalaSource in Test).value
+// This includes tests sources in the assembled fat-jar:
+fullClasspath in assembly := (fullClasspath in Test).value
+
+// This turns on fat-jar publishing during release process:
+publishFatArtifact in Release := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
-// resolvers += "Era7 maven snapshots" at "https://s3-eu-west-1.amazonaws.com/snapshots.era7.com"
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.7.0")
-addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"     % "0.5.0")
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2-8-gc3118aa")

--- a/src/main/scala/ohnosequences/loquat/configs/loquat.scala
+++ b/src/main/scala/ohnosequences/loquat/configs/loquat.scala
@@ -39,7 +39,7 @@ abstract class AnyLoquatConfig extends AnyConfig {
 
   val terminationConfig: TerminationConfig
 
-  val dataMappings: List[AnyDataMapping]
+  // val dataMappings: List[AnyDataMapping]
 
   /* This setting switches the check of existence of the input S3 objects */
   val checkInputObjects: Boolean = true
@@ -79,52 +79,53 @@ abstract class AnyLoquatConfig extends AnyConfig {
   )
 
   def validationErrors(aws: AWSClients): Seq[String] = {
+    ???
 
-    logger.info("Checking that data mappings define all the needed data keys...")
-    dataMappings.find {
-      _.checkDataKeys.nonEmpty
-    } match {
-
-      case Some(dm) => dm.checkDataKeys
-
-      case _ => {
-
-        logger.info("Checking the fat-artifact existence...")
-        if (aws.s3.objectExists(fatArtifactS3Object).isFailure) {
-          Seq(s"Couldn't access the artifact at [${fatArtifactS3Object.url}] (probably you forgot to publish it)")
-        } else if(checkInputObjects) {
-
-          logger.info("Checking input S3 objects existence...")
-
-          print("[")
-
-          val errors: Seq[String] = dataMappings flatMap { dataMapping =>
-
-            // if an input object doesn't exist, we return an arror message
-            dataMapping.remoteInput flatMap {
-              case (dataKey, S3Resource(s3address)) => {
-                val exists: Boolean = Try(
-                  aws.s3.s3.listObjects(s3address.bucket, s3address.key).getObjectSummaries
-                ).filter{ _.length > 0 }.isSuccess
-
-                if (exists) print("+") else print("-")
-                // logger.debug(s"[${dataMapping.id}]: [${dataKey.label}] -> [${s3address.url}] ${if(exists) "exists" else "DOESN'T exist!"}")
-
-                if (exists) None
-                else Some(s"Input object [${dataKey.label}] doesn't exist at the address: [${s3address.url}]")
-              }
-              // if the mapping is not an S3Resource, we don't check
-              case _ => None
-            }
-          }
-
-          println("]")
-
-          errors
-
-        } else Seq()
-      }
-    }
+    // logger.info("Checking that data mappings define all the needed data keys...")
+    // dataMappings.find {
+    //   _.checkDataKeys.nonEmpty
+    // } match {
+    //
+    //   case Some(dm) => dm.checkDataKeys
+    //
+    //   case _ => {
+    //
+    //     logger.info("Checking the fat-artifact existence...")
+    //     if (aws.s3.objectExists(fatArtifactS3Object).isFailure) {
+    //       Seq(s"Couldn't access the artifact at [${fatArtifactS3Object.url}] (probably you forgot to publish it)")
+    //     } else if(checkInputObjects) {
+    //
+    //       logger.info("Checking input S3 objects existence...")
+    //
+    //       print("[")
+    //
+    //       val errors: Seq[String] = dataMappings flatMap { dataMapping =>
+    //
+    //         // if an input object doesn't exist, we return an arror message
+    //         dataMapping.remoteInput flatMap {
+    //           case (dataKey, S3Resource(s3address)) => {
+    //             val exists: Boolean = Try(
+    //               aws.s3.s3.listObjects(s3address.bucket, s3address.key).getObjectSummaries
+    //             ).filter{ _.length > 0 }.isSuccess
+    //
+    //             if (exists) print("+") else print("-")
+    //             // logger.debug(s"[${dataMapping.id}]: [${dataKey.label}] -> [${s3address.url}] ${if(exists) "exists" else "DOESN'T exist!"}")
+    //
+    //             if (exists) None
+    //             else Some(s"Input object [${dataKey.label}] doesn't exist at the address: [${s3address.url}]")
+    //           }
+    //           // if the mapping is not an S3Resource, we don't check
+    //           case _ => None
+    //         }
+    //       }
+    //
+    //       println("]")
+    //
+    //       errors
+    //
+    //     } else Seq()
+    //   }
+    // }
   }
 
 }

--- a/src/main/scala/ohnosequences/loquat/configs/loquat.scala
+++ b/src/main/scala/ohnosequences/loquat/configs/loquat.scala
@@ -79,53 +79,10 @@ abstract class AnyLoquatConfig extends AnyConfig {
   )
 
   def validationErrors(aws: AWSClients): Seq[String] = {
-    ???
-
-    // logger.info("Checking that data mappings define all the needed data keys...")
-    // dataMappings.find {
-    //   _.checkDataKeys.nonEmpty
-    // } match {
-    //
-    //   case Some(dm) => dm.checkDataKeys
-    //
-    //   case _ => {
-    //
-    //     logger.info("Checking the fat-artifact existence...")
-    //     if (aws.s3.objectExists(fatArtifactS3Object).isFailure) {
-    //       Seq(s"Couldn't access the artifact at [${fatArtifactS3Object.url}] (probably you forgot to publish it)")
-    //     } else if(checkInputObjects) {
-    //
-    //       logger.info("Checking input S3 objects existence...")
-    //
-    //       print("[")
-    //
-    //       val errors: Seq[String] = dataMappings flatMap { dataMapping =>
-    //
-    //         // if an input object doesn't exist, we return an arror message
-    //         dataMapping.remoteInput flatMap {
-    //           case (dataKey, S3Resource(s3address)) => {
-    //             val exists: Boolean = Try(
-    //               aws.s3.s3.listObjects(s3address.bucket, s3address.key).getObjectSummaries
-    //             ).filter{ _.length > 0 }.isSuccess
-    //
-    //             if (exists) print("+") else print("-")
-    //             // logger.debug(s"[${dataMapping.id}]: [${dataKey.label}] -> [${s3address.url}] ${if(exists) "exists" else "DOESN'T exist!"}")
-    //
-    //             if (exists) None
-    //             else Some(s"Input object [${dataKey.label}] doesn't exist at the address: [${s3address.url}]")
-    //           }
-    //           // if the mapping is not an S3Resource, we don't check
-    //           case _ => None
-    //         }
-    //       }
-    //
-    //       println("]")
-    //
-    //       errors
-    //
-    //     } else Seq()
-    //   }
-    // }
+    logger.info("Checking the fat-artifact existence...")
+    if (aws.s3.objectExists(fatArtifactS3Object).isFailure) {
+      Seq(s"Couldn't access the artifact at [${fatArtifactS3Object.url}] (probably you forgot to publish it)")
+    } else Seq()
   }
 
 }

--- a/src/main/scala/ohnosequences/loquat/loquats.scala
+++ b/src/main/scala/ohnosequences/loquat/loquats.scala
@@ -16,15 +16,17 @@ trait AnyLoquat { loquat =>
   type Config <: AnyLoquatConfig
   val  config: Config
 
-  type DataProcessingBundle <: AnyDataProcessingBundle
-  val  instructionsBundle: DataProcessingBundle
+  type DataProcessing <: AnyDataProcessingBundle
+  val  dataProcessing: DataProcessing
+
+  val dataMappings: List[DataMapping[DataProcessing]]
 
   lazy val fullName: String = this.getClass.getName.split("\\$").mkString(".")
 
   // Bundles hierarchy:
-  case object worker extends WorkerBundle(instructionsBundle, config)
+  case object worker extends WorkerBundle(dataProcessing, config)
 
-  case object manager extends ManagerBundle(worker) {
+  case object manager extends ManagerBundle(worker)(dataMappings) {
     override lazy val fullName: String = s"${loquat.fullName}.${this.toString}"
   }
 
@@ -42,11 +44,12 @@ trait AnyLoquat { loquat =>
 
 abstract class Loquat[
   C <: AnyLoquatConfig,
-  I <: AnyDataProcessingBundle
-](val config: C, val instructionsBundle: I) extends AnyLoquat {
+  DP <: AnyDataProcessingBundle
+](val config: C, val dataProcessing: DP
+)(val dataMappings: List[DataMapping[DP]]) extends AnyLoquat {
 
   type Config = C
-  type DataProcessingBundle = I
+  type DataProcessing = DP
 }
 
 

--- a/src/main/scala/ohnosequences/loquat/manager.scala
+++ b/src/main/scala/ohnosequences/loquat/manager.scala
@@ -37,7 +37,7 @@ trait AnyManagerBundle extends AnyBundle with LazyLogging { manager =>
 
   val bundleDependencies: List[AnyBundle] = List(
     LogUploaderBundle(config, scheduler),
-    TerminationDaemonBundle(config, scheduler)
+    TerminationDaemonBundle(config, scheduler, dataMappings.length)
   )
 
   lazy val aws = instanceAWSClients(config)

--- a/src/main/scala/ohnosequences/loquat/terminator.scala
+++ b/src/main/scala/ohnosequences/loquat/terminator.scala
@@ -78,7 +78,8 @@ case class TerminationDaemonBundle(
 
     lazy val afterInitial = TerminateAfterInitialDataMappings(
       config.terminationConfig.terminateAfterInitialDataMappings,
-      config.dataMappings.length,
+      //FIXME: dataMappings.length
+      ???,
       successResults.size
     )
     logger.debug(s"${afterInitial}: ${afterInitial.check}")

--- a/src/main/scala/ohnosequences/loquat/terminator.scala
+++ b/src/main/scala/ohnosequences/loquat/terminator.scala
@@ -21,7 +21,8 @@ import better.files._
 private[loquat]
 case class TerminationDaemonBundle(
   val config: AnyLoquatConfig,
-  val scheduler: Scheduler
+  val scheduler: Scheduler,
+  val initialCount: Int
 ) extends Bundle() with LazyLogging {
 
   lazy val aws = instanceAWSClients(config)
@@ -78,8 +79,7 @@ case class TerminationDaemonBundle(
 
     lazy val afterInitial = TerminateAfterInitialDataMappings(
       config.terminationConfig.terminateAfterInitialDataMappings,
-      //FIXME: dataMappings.length
-      ???,
+      initialCount,
       successResults.size
     )
     logger.debug(s"${afterInitial}: ${afterInitial.check}")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
This will allow defining pipelines of loquats easier:
- define dataflow (a chain of data-mappings)
- define a cover pipeline constructor which
  + takes a dataflow
  + requires to provide config for each loquat
  + defines loquats based on those configs and data-mappings 

Maybe it's worth adding a `DataProcessing` reference to the config, then the `Loquat` constructor will look like

```scala
abstract class Loquat[C <: AnyLoquatConfig](val config: C)
  (val dataMappings: List[DataMapping[C#DataProcessing]])
```