### PR TITLE
Send a notification if a manager instance fails during installation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ dependencyOverrides ++= Set(
 
 // FIXME: warts should be turn on back after the code clean up
 wartremoverErrors in (Compile, compile) := Seq()
+wartremoverErrors in (Test,    compile) := Seq()
 
 
 generateStatikaMetadataIn(Test)

--- a/src/main/scala/ohnosequences/loquat/manager.scala
+++ b/src/main/scala/ohnosequences/loquat/manager.scala
@@ -111,8 +111,7 @@ trait AnyManagerBundle extends AnyBundle with LazyLogging { manager =>
             config.workersConfig.autoScalingGroup(
               config.resourceNames.workersGroup,
               keypairName,
-              // config.iamRoleName
-              "foo"
+              config.iamRoleName
             ),
             workerCompat.userScript
           )
@@ -123,7 +122,7 @@ trait AnyManagerBundle extends AnyBundle with LazyLogging { manager =>
           logger.debug("Waiting for the workers autoscaling group creation")
           utils.waitForResource(
             getResource = aws.as.getAutoScalingGroupByName(workersGroup.name),
-            tries = 0,
+            tries = 30,
             timeStep = 5.seconds
           )
 
@@ -139,11 +138,12 @@ trait AnyManagerBundle extends AnyBundle with LazyLogging { manager =>
         logger.error("Manager failed, trying to restart it")
 
         val subject = s"Loquat ${config.loquatId} manager failed during installation"
-        val logTail = loggerBundle.logFile.lines.toSeq.takeRight(30).mkString("\n") // 30 last lines
-        val message = s"""Full log is at
-          |  ${loggerBundle.logS3.getOrElse("Failed to get log S3 location")}
+        val logTail = loggerBundle.logFile.lines.toSeq.takeRight(20).mkString("\n") // 20 last lines
+        val message = s"""${subject}.
+          |Full log is at [${loggerBundle.logS3.getOrElse("Failed to get log S3 location")}]
           |Here is its tail:
           |
+          |[...]
           |${logTail}
           |""".stripMargin
 

--- a/src/main/scala/ohnosequences/loquat/manager.scala
+++ b/src/main/scala/ohnosequences/loquat/manager.scala
@@ -139,7 +139,7 @@ trait AnyManagerBundle extends AnyBundle with LazyLogging { manager =>
 
         val subject = s"Loquat ${config.loquatId} manager failed during installation"
         val logTail = loggerBundle.logFile.lines.toSeq.takeRight(20).mkString("\n") // 20 last lines
-        val message = s"""${subject}.
+        val message = s"""${subject}. It will try to restart. If it's a fatal failure, you should manually undeploy the loquat.
           |Full log is at [${loggerBundle.logS3.getOrElse("Failed to get log S3 location")}]
           |Here is its tail:
           |

--- a/src/test/scala/ohnosequences/loquat/test/config.scala
+++ b/src/test/scala/ohnosequences/loquat/test/config.scala
@@ -3,6 +3,7 @@ package ohnosequences.loquat.test
 import ohnosequences.loquat._
 import ohnosequences.awstools._, regions.Region._, ec2._, InstanceType._, autoscaling._
 import ohnosequences.statika._, aws._
+import test.dataProcessing._
 
 case object config {
 
@@ -18,7 +19,7 @@ case object config {
     // type AMI = defaultAMI.type
     // lazy val ami: AMI = defaultAMI
 
-    val metadata: AnyArtifactMetadata = generated.metadata.Loquat
+    val metadata: AnyArtifactMetadata = ohnosequences.generated.metadata.loquat
 
     val  managerConfig = ManagerConfig(
       InstanceSpecs(defaultAMI, m3.medium),
@@ -35,13 +36,13 @@ case object config {
       terminateAfterInitialDataMappings = true
     )
 
-    val N = 10000
-    val dataMappings: List[AnyDataMapping] = (1 to N).toList.map{ _ => test.dataMappings.dataMapping }
-
-    override val checkInputObjects = false
+    override val checkInputObjects = true
   }
 
-  case object testLoquat extends Loquat(testConfig, test.dataProcessing.processingBundle)
+  val N = 10
+  val dataMappings: List[DataMapping[processingBundle.type]] = (1 to N).toList.map{ _ => test.dataMappings.dataMapping }
+
+  case object testLoquat extends Loquat(testConfig, processingBundle)(dataMappings)
 
   val testUser = LoquatUser(
     email = "aalekhin@ohnosequences.com",


### PR DESCRIPTION
Currently, if manager fails during installation, you likely won't get any log (sometimes it fails exactly because of the problems with uploading log), so you will just see managers that quickly fail and relaunch (and this will be an infinite loop if you won't undeploy manually). So what you need to do to figure out the problem is to wait for a new instance and ssh into it very quickly to see the log's tail:

```
 -- applying --

List(TerminationDaemonBundle(flashConfig), LogUploaderBundle(flashConfig), manager)
00:40:31.342 [main] INFO  o.loquat.AnyLoquat$manager$ - manager is started
00:40:31.411 [main] INFO  o.loquat.AnyLoquat$manager$ - checking if the initial dataMappings are uploaded
00:40:32.329 [main] ERROR o.loquat.AnyLoquat$manager$ - Manager failed, trying to restart it
The specified bucket does not exist (Service: Amazon S3; Status Code: 404; Error Code: NoSuchBucket; Request ID: 42EF804B464F4E18)
ohnosequences.statika.instructions$LazyTry$$anon$1@47a5b70d
Manager failed during installation
Exception in thread "main" java.lang.RuntimeException: List(The specified bucket does not exist (Service: Amazon S3; Status Code: 404; Error Code: NoSuchBucket; Request ID: 42EF804B464F4E18), ohnosequences.statika.instructions$LazyTry$$anon$1@47a5b70d, Manager failed during installation)
	at scala.sys.package$.error(package.scala:27)
	at apply$.main(apply.scala:5)
	at apply.main(apply.scala)

 -- failure --
```

Would be very useful to send this piece of log in the notification email.

Also it probably worths undeploying loquat automatically in such cases instead of just relaunching manager.