### PR TITLE
Use S3Folder for logs instead of just bucket name

### DIFF
--- a/src/main/scala/ohnosequences/loquat/configs/loquat.scala
+++ b/src/main/scala/ohnosequences/loquat/configs/loquat.scala
@@ -29,8 +29,8 @@ abstract class AnyLoquatConfig extends AnyConfig {
   /* IAM role that will be used by the autoscaling groups */
   val iamRoleName: String
 
-  /* An S3 bucket for saving logs */
-  val logsBucketName: String
+  /* An S3 folder for saving instance logs */
+  val logsS3Prefix: S3Folder
 
   /* Metadata generated for your loquat project */
   val metadata: AnyArtifactMetadata
@@ -64,7 +64,7 @@ abstract class AnyLoquatConfig extends AnyConfig {
   lazy final val artifactVersion: String = metadata.version.replace(".", "-").toLowerCase
   lazy final val loquatId: String = s"${loquatName}-${artifactName}-${artifactVersion}"
 
-  lazy final val resourceNames: ResourceNames = ResourceNames(loquatId, logsBucketName)
+  lazy final val resourceNames: ResourceNames = ResourceNames(loquatId, logsS3Prefix)
 
 
 

--- a/src/main/scala/ohnosequences/loquat/configs/resources.scala
+++ b/src/main/scala/ohnosequences/loquat/configs/resources.scala
@@ -1,8 +1,10 @@
 package ohnosequences.loquat
 
+import ohnosequences.awstools.s3.S3Folder
+
 /* Configuration of resources */
 private[loquat]
-case class ResourceNames(prefix: String, bucketName: String) {
+case class ResourceNames(prefix: String, logsS3Prefix: S3Folder) {
   /* name of queue with dataMappings */
   val inputQueue: String = prefix + "-loquat-input"
   /* name of topic for dataMappings result notifications */
@@ -10,7 +12,7 @@ case class ResourceNames(prefix: String, bucketName: String) {
   /* name of queue with errors (will be subscribed to errorTopic) */
   val errorQueue: String = prefix + "-loquat-errors"
   /* name of bucket for logs files */
-  val bucket: String = bucketName
+  val logs: S3Folder = logsS3Prefix / prefix /
   /* topic name to notify user about termination of loquat */
   val notificationTopic: String = prefix + "-loquat-notifications"
   /* name of the manager autoscaling group */

--- a/src/main/scala/ohnosequences/loquat/loquats.scala
+++ b/src/main/scala/ohnosequences/loquat/loquats.scala
@@ -173,13 +173,15 @@ case object LoquatOps extends LazyLogging {
           Step( s"Creating error queue: ${names.errorQueue}" )(
             aws.sqs.getOrCreateQueue(names.errorQueue)
           ),
-          Step( s"Checking the bucket: ${names.bucket}" )(
+          Step( s"Checking logs bucket: ${names.logs}" )(
             Try {
-              if(aws.s3.doesBucketExist(names.bucket)) {
-                logger.info(s"Bucket [${names.bucket}] already exists.")
+              val logsBucket = names.logs.bucket
+
+              if(aws.s3.doesBucketExist(logsBucket)) {
+                logger.info(s"Bucket [${logsBucket}] already exists.")
               } else {
-                logger.info(s"Bucket [${names.bucket}] doesn't exists. Trying to create it.")
-                aws.s3.createBucket(names.bucket)
+                logger.info(s"Bucket [${logsBucket}] doesn't exists. Trying to create it.")
+                aws.s3.createBucket(logsBucket)
               }
             }
           ),

--- a/src/main/scala/ohnosequences/loquat/manager.scala
+++ b/src/main/scala/ohnosequences/loquat/manager.scala
@@ -178,7 +178,7 @@ trait AnyManagerBundle extends AnyBundle with LazyLogging { manager =>
         val subject = s"Loquat ${config.loquatId} manager failed during installation"
         val logTail = loggerBundle.logFile.lines.toSeq.takeRight(20).mkString("\n") // 20 last lines
         val message = s"""${subject}. It will try to restart. If it's a fatal failure, you should manually undeploy the loquat.
-          |Full log is at [${loggerBundle.logS3.getOrElse("Failed to get log S3 location")}]
+          |Full log is at [${loggerBundle.logS3}]
           |Here is its tail:
           |
           |[...]


### PR DESCRIPTION
In the loquat configuration use `S3Folder` type as the destination for logs (still need to create bucket on deploy if it doesn't exist). See https://github.com/ohnosequences/mg7/pull/112#discussion_r76400310
