### PR TITLE
Drop upickle dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,6 @@ libraryDependencies ++= Seq(
   // logging:
   "ch.qos.logback"              % "logback-classic" % "1.1.8",
   "com.typesafe.scala-logging" %% "scala-logging"   % "3.5.0",
-  // json:
-  "com.lihaoyi" %% "upickle" % "0.4.4",
   // AWS:
   "ohnosequences" %% "aws-scala-tools" % "0.18.1",
   // files:

--- a/src/main/scala/ohnosequences/loquat/dataMappings.scala
+++ b/src/main/scala/ohnosequences/loquat/dataMappings.scala
@@ -8,7 +8,6 @@ import ohnosequences.cosas._, records._, fns._, types._, klists._
 import ohnosequences.awstools.s3._
 
 import better.files._
-import upickle.Js
 
 
 trait AnyDataMapping { dataMapping =>
@@ -77,4 +76,35 @@ private[loquat] case class SimpleDataMapping(
   val id: String,
   val inputs: Map[String, AnyRemoteResource],
   val outputs: Map[String, S3Resource]
-)
+) {
+  import java.io._
+
+  def serialize: String = {
+    val byteStream = new ByteArrayOutputStream()
+    val objOutStream = new ObjectOutputStream(byteStream)
+
+    objOutStream.writeObject(this)
+    val str = byteStream.toString
+
+    objOutStream.close()
+    byteStream.close()
+
+    str
+  }
+}
+
+case object SimpleDataMapping {
+  import java.io._
+
+  def deserialize(str: String): SimpleDataMapping = {
+    val byteStream = new ByteArrayInputStream(str.getBytes)
+    val objInStream = new ObjectInputStream(byteStream)
+
+    val sdm = objInStream.readObject.asInstanceOf[SimpleDataMapping]
+
+    objInStream.close()
+    byteStream.close()
+
+    sdm
+  }
+}

--- a/src/main/scala/ohnosequences/loquat/dataProcessing.scala
+++ b/src/main/scala/ohnosequences/loquat/dataProcessing.scala
@@ -9,7 +9,6 @@ import ohnosequences.cosas._, types._, typeUnions._, records._, fns._, klists._
 
 import ohnosequences.statika._
 
-import upickle.Js
 import better.files._
 
 

--- a/src/main/scala/ohnosequences/loquat/manager.scala
+++ b/src/main/scala/ohnosequences/loquat/manager.scala
@@ -67,13 +67,11 @@ trait AnyManagerBundle extends AnyBundle with LazyLogging { manager =>
       }
 
     val msgs: Iterator[String] = dataMappings.toIterator.zipWithIndex.map { case (dataMapping, ix) =>
-      upickle.default.write[SimpleDataMapping](
-        SimpleDataMapping(
-          id = ix.toString,
-          inputs = toMap(dataMapping.remoteInput),
-          outputs = toMap(dataMapping.remoteOutput)
-        )
-      )
+      SimpleDataMapping(
+        id = ix.toString,
+        inputs = toMap(dataMapping.remoteInput),
+        outputs = toMap(dataMapping.remoteOutput)
+      ).serialize
     }
 
 

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -146,14 +146,13 @@ class DataProcessor(
   ): AnyResult = {
 
     try {
-
-      logger.info("Preparing dataMapping input")
+      logger.debug("Preparing dataMapping input")
 
       val inputDir = (workingDir / "input").createDirectories()
 
       val inputFiles: Map[String, File] = dataMapping.inputs.map { case (name, resource) =>
 
-        logger.debug(s"Trying to create input object [${name}]")
+        logger.debug(s"Trying to create input object [${name}] from \n${resource}")
 
         resource match {
           case MessageResource(msg) => {
@@ -172,7 +171,7 @@ class DataProcessor(
         }
       }
 
-      logger.info("Processing data in: " + workingDir.path)
+      // logger.debug("Processing data in: " + workingDir.path)
       val result = instructionsBundle.runProcess(workingDir, inputFiles)
 
       val resultDescription = ProcessingResult(dataMapping.id, result.toString)
@@ -261,15 +260,15 @@ class DataProcessor(
       try {
         val transferManager = aws.s3.createTransferManager
 
-        logger.info("Data processor is waiting for new data")
+        logger.info("Waiting for new data")
 
         val message = waitForTask()
 
         // instance.foreach(_.createTag(StatusTag.processing))
-        logger.info("DataProcessor: received message " + message)
         val dataMapping = SimpleDataMapping.deserialize(message.body)
 
-        logger.info("DataProcessor processing message")
+        logger.info(s"Processing message [${dataMapping.id}]")
+
         import scala.concurrent.ExecutionContext.Implicits._
         val futureResult = Future {
           processDataMapping(transferManager, dataMapping, workingDir)

--- a/src/main/scala/ohnosequences/loquat/worker.scala
+++ b/src/main/scala/ohnosequences/loquat/worker.scala
@@ -13,7 +13,6 @@ import better.files._
 import scala.concurrent._, duration._
 import scala.util.Try
 import java.nio.file.Files
-import upickle.Js
 
 
 trait AnyWorkerBundle extends AnyBundle {
@@ -217,7 +216,7 @@ class DataProcessor(
             // TODO: check whether we can fold Try's here somehow
             if (uploadTries.forall(_.isSuccess)) {
               logger.info("Finished uploading output files. publishing message to the output queue.")
-              outputQueue.sendOne(upickle.default.write(resultDescription))
+              outputQueue.sendOne(resultDescription.toString)
               result //-&- success(s"task [${dataMapping.id}] is successfully finished", ())
             } else {
               logger.error(s"Some uploads failed: ${uploadTries.filter(_.isFailure)}")
@@ -268,7 +267,7 @@ class DataProcessor(
 
         // instance.foreach(_.createTag(StatusTag.processing))
         logger.info("DataProcessor: received message " + message)
-        val dataMapping = upickle.default.read[SimpleDataMapping](message.body)
+        val dataMapping = SimpleDataMapping.deserialize(message.body)
 
         logger.info("DataProcessor processing message")
         import scala.concurrent.ExecutionContext.Implicits._

--- a/src/test/scala/ohnosequences/loquat/test/serialization.scala
+++ b/src/test/scala/ohnosequences/loquat/test/serialization.scala
@@ -1,0 +1,20 @@
+package ohnosequences.loquat.test
+
+import ohnosequences.loquat._, utils._, test.data._, dataMappings._
+
+class Serialization extends org.scalatest.FunSuite {
+
+  val simpleDataMapping = SimpleDataMapping(
+    id = dataMapping.label.toString,
+    inputs = toMap(dataMapping.remoteInput),
+    outputs = toMap(dataMapping.remoteOutput)
+  )
+
+  test("Serialize-deserialize") {
+
+    val str = simpleDataMapping.serialize
+    val sdm = SimpleDataMapping.deserialize(str)
+
+    assert { simpleDataMapping == sdm }
+  }
+}


### PR DESCRIPTION
Currently it's used only for (de)serializing 

```scala
case class SimpleDataMapping(
  val id: String,
  val inputs: Map[String, AnyRemoteResource],
  val outputs: Map[String, S3Resource]
)
```

to be able to send/recieve it in the SQS messages. I think it's not worth having a dependency on upickle library if we can use Java serialization (this case is very simple and has clear restricted context: send message/recieve message).

----

Here's a draft implementation. It's quite straightforward (and ugly), but probably can be done simpler.

```scala
case object SimpleDataMapping {
  import java.io._

  def serialize(sdm: SimpleDataMapping): String = {
    val byteStream = new ByteArrayOutputStream()
    val objOutStream = new ObjectOutputStream(byteStream)

    objOutStream.writeObject(sdm)
    val str = byteStream.toString

    objOutStream.close()
    byteStream.close()

    str
  }

  def deserialize(str: String): SimpleDataMapping = {
    val byteStream = new ByteArrayInputStream(str.getBytes)
    val objInStream = new ObjectInputStream(byteStream)

    val sdm = objInStream.readObject.asInstanceOf[SimpleDataMapping]

    objInStream.close()
    byteStream.close()

    sdm
  }
}
```

----

@eparejatobes 

- is there any simpler way to do it?
- do you have any general objections?

