### PR TITLE
Improve local launcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ description  := "🍋"
 organization := "ohnosequences"
 bucketSuffix := "era7.com"
 
-crossScalaVersions := Seq("2.11.11", "2.12.3")
+crossScalaVersions := Seq("2.11.12", "2.12.4")
 scalaVersion  := crossScalaVersions.value.last
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.1.0

--- a/src/main/scala/ohnosequences/loquat/loquats.scala
+++ b/src/main/scala/ohnosequences/loquat/loquats.scala
@@ -215,10 +215,11 @@ case object LoquatOps extends LazyLogging {
           util.Success(true)
         } { (result: Try[_], next: Step[_]) =>
           result.flatMap(_ => next.execute)
-        }
-        resultToTry(
-          manager.localInstructions(user).run(localTargetTmpDir())
-        ).map { _ =>
+        }.flatMap { _ =>
+          resultToTry(
+            manager.localInstructions(user).run(localTargetTmpDir())
+          )
+        }.map { _ =>
           monitorProgress(config, dataMappings.length, interval)
         }
       }

--- a/src/main/scala/ohnosequences/loquat/loquats.scala
+++ b/src/main/scala/ohnosequences/loquat/loquats.scala
@@ -41,8 +41,11 @@ trait AnyLoquat { loquat =>
       AWSClients(config.region, user.localCredentials),
       TerminateManually
     )
-  final def launchLocally(user: LoquatUser): Try[ScheduledFuture[_]] =
-    LoquatOps.launchLocally(config, user, dataProcessing, dataMappings, manager)
+  final def launchLocally(
+    user: LoquatUser,
+    interval: FiniteDuration = 3.minutes
+  ): Try[ScheduledFuture[_]] =
+    LoquatOps.launchLocally(config, user, dataProcessing, dataMappings, manager, interval)
 
   final def monitorProgress(interval: FiniteDuration): ScheduledFuture[_] =
     LoquatOps.monitorProgress(

--- a/src/main/scala/ohnosequences/loquat/terminator.scala
+++ b/src/main/scala/ohnosequences/loquat/terminator.scala
@@ -5,6 +5,7 @@ import ohnosequences.statika._
 import ohnosequences.awstools._, sqs._, autoscaling._, regions._
 import com.typesafe.scalalogging.LazyLogging
 import scala.concurrent.duration._
+import java.util.concurrent.ScheduledFuture
 
 case class TerminationDaemonBundle(
   val config: AnyLoquatConfig,
@@ -37,7 +38,7 @@ case class TerminationDaemonBundle(
   def checkAndTerminate(
     after: FiniteDuration,
     every: FiniteDuration
-  ) = {
+  ): ScheduledFuture[_] = {
     scheduler.repeat(after, every){
       checkConditions(recheck = false)
     }

--- a/src/test/scala/ohnosequences/loquat/test/config.scala
+++ b/src/test/scala/ohnosequences/loquat/test/config.scala
@@ -37,7 +37,7 @@ case object config {
     override val sqsInitialTimeout: FiniteDuration = 20.seconds
   }
 
-  val N = 100
+  val N = 10
   val dataMappings: List[DataMapping[processingBundle.type]] = (1 to N).toList.map{ _ => test.dataMappings.dataMapping }
 
   case object testLoquat extends Loquat(testConfig, processingBundle)(dataMappings)

--- a/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
+++ b/src/test/scala/ohnosequences/loquat/test/dataProcessing.scala
@@ -3,8 +3,8 @@ package ohnosequences.loquat.test
 import ohnosequences.datasets._
 import ohnosequences.loquat._, utils._, utils.files._, test.data._
 import ohnosequences.statika._
-import ohnosequences.datasets._, FileResource._
-import ohnosequences.cosas._, klists._, types._, records._
+import ohnosequences.datasets._
+import ohnosequences.cosas._, types._, records._
 import concurrent.duration._
 
 case object dataProcessing {

--- a/src/test/scala/ohnosequences/loquat/test/test.scala
+++ b/src/test/scala/ohnosequences/loquat/test/test.scala
@@ -1,0 +1,22 @@
+package ohnosequences.loquat.test
+
+import ohnosequences.datasets._
+import ohnosequences.loquat._, utils._, utils.files._, test.data._
+import ohnosequences.statika._
+import ohnosequences.datasets._
+import ohnosequences.cosas._, types._, records._
+import concurrent.duration._
+import java.util.concurrent._
+
+class LoquatSuite extends org.scalatest.FunSuite {
+
+  test("launching loquat locally and waiting for its termination") {
+    config.testLoquat.launchLocally(config.testUser).map { monitor =>
+      val result = monitor.get(10, TimeUnit.MINUTES)
+      info(result.toString)
+      assert(monitor.isDone)
+    }.getOrElse {
+      failure("Couldn't launch loquat")
+    }
+  }
+}

--- a/src/test/scala/ohnosequences/loquat/test/test.scala
+++ b/src/test/scala/ohnosequences/loquat/test/test.scala
@@ -11,9 +11,11 @@ import java.util.concurrent._
 class LoquatSuite extends org.scalatest.FunSuite {
 
   test("launching loquat locally and waiting for its termination") {
-    config.testLoquat.launchLocally(config.testUser).map { monitor =>
-      val result = monitor.get(10, TimeUnit.MINUTES)
-      info(result.toString)
+    config.testLoquat.launchLocally(
+      user = config.testUser,
+      interval = 30.seconds
+    ).map { monitor =>
+      monitor.get(15, TimeUnit.MINUTES)
       assert(monitor.isDone)
     }.getOrElse {
       failure("Couldn't launch loquat")


### PR DESCRIPTION
- [x] return `ScheduledFuture` from it, so that the caller can wait for its termination
- [ ] adapt the code in https://github.com/era7bio/repseqmiodx/pull/107 and https://github.com/era7bio/webmiodx/pull/97
- [x] use it to automate simple test launch